### PR TITLE
fix deprecated_core_config

### DIFF
--- a/custom_components/pr_custom_component/__init__.py
+++ b/custom_components/pr_custom_component/__init__.py
@@ -12,12 +12,13 @@ import logging
 from typing import List, Text
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession,
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.typing import ConfigType
 import yarl
 
 from .api import PRCustomComponentApiClient
@@ -28,7 +29,7 @@ SCAN_INTERVAL = timedelta(days=1)
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-async def async_setup(hass: HomeAssistant, config: Config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up this integration using YAML is not supported."""
     return True
 


### PR DESCRIPTION
removes warning by fixing the deprecated config class import.
see: https://github.com/home-assistant/core/blob/7e5617fd5448fb7c11b857430c6fae06cf5ac0df/homeassistant/core.py#L188